### PR TITLE
Minor changes re devcontainer and rust analyzer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,14 +16,14 @@
 	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"remoteUser": "root",
 
 	// Add the IDs of extensions you want installed when the container is created.	
 	"customizations": {
 		"vscode": {
 			"extensions": [
 				"rust-lang.rust-analyzer",
-				"bungcip.better-toml",
+				"tamasfe.even-better-toml",
 				"vadimcn.vscode-lldb",
 				"usernamehw.errorlens",
 				"gruntfuggly.todo-tree",				

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
-    "rust-analyzer.linkedProjects": [
-        "wasm-shims/Cargo.toml",
+    "rust-analyzer.linkedProjects": [        
         "Cargo.toml",
         "tests/Cargo.toml",
         "crates/order-management/Cargo.toml",


### PR DESCRIPTION
Minor updates:
1. Removed unused Rust Analyzer target.
2. Changed devcontainer.json to use root as it fails in codespace otherwise while helm installation in make and updated deprecated toml ext. 
